### PR TITLE
Omit DBA container

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -17,6 +17,7 @@ use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
 nodejs_version: "16"
+omit_containers: [dba]
 
 # Key features of ddev's config.yaml:
 


### PR DESCRIPTION
This omits the DBA (PhpMyAdmin) container, because there are plenty of better database management tools around.